### PR TITLE
Building up the struct fields

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 Soss = "8ce77f84-9b61-11e8-39ff-d17a774bf41c"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 MLJModelInterface = "0.3"

--- a/mainexample.jl
+++ b/mainexample.jl
@@ -1,0 +1,36 @@
+using Soss
+using MLJ
+using SossMLJ
+using MLJModelInterface
+const MMI = MLJModelInterface
+
+m = @model X,α,σ begin
+    k = size(X,2)
+    β ~ Normal(0,α) |> iid(k)
+    yhat = X * β
+    y ~ For(eachindex(yhat)) do j
+        Normal(yhat[j], σ)
+    end
+end
+
+X = (a=randn(10), b=randn(10), c=randn(10))
+
+params = (α=2.0, σ=1.0)
+
+
+mdl = SossMLJ.SossMLJModel(params, X -> (X=MMI.matrix(X),), m, dynamicHMC)
+
+args = merge(mdl.transform(X), params)
+
+truth = rand(m(args))
+y = truth.y
+
+mach = machine(mdl, X, y)
+fit!(mach)
+
+
+predictor = MLJ.predict(mach, X)
+
+rand.(predictor)
+
+


### PR DESCRIPTION
@DilumAluthge here's my current thought for setting this up. First, a model can be specified as

```julia
mutable struct SossMLJModel{H,T,M,I} <: MLJModelInterface.Probabilistic
    hyperparams :: H
    transform :: T
    model :: M
    infer :: I
end
```

The idea is that when a user passes `X`, the arguments to Soss will be 
```julia
args = merge(hyperparams, transform(X))
```

So if a model needs `X::Matrix`, we'd have something like

```julia
transform(X) = (X = MLJModelInterface.matrix(X),)
```

Then upon `fit`ting the model, we'll have

```julia
struct MixedVariate <: Dists.VariateForm end
struct MixedSupport <: Dists.ValueSupport end

struct SossMLJPredictor{M} <: Distributions.Sampleable{MixedVariate, MixedSupport}
    model :: M
    post 
    pred
    X
end
```

So `post` is the sample from the posterior, `pred` is the predictive model, and `X` is... Hmm, should this store the original `X` passed into the machine? Or would we be better off passing `args` as described above?