### PR TITLE
Temporarily disable CI on Julia nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         version:
           - '1.3'
           - '1'
-          - 'nightly'
+          # - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest


### PR DESCRIPTION
The CI failures on Julia nightly are known.

As soon as I merge this PR, I'll make another PR to "re-enable CI on Julia nightly." I'll keep that PR open, rebasing it every time another PR is merged. Then, when we finally get CI working on Julia nightly, that PR will be all green, and we'll merge it. Thus, we can monitor that PR as a way of keeping track of whether or not CI is passing on Julia nightly.