### PR TITLE
Implement the `MLJModelInterface.predict_mean` method

### DIFF
--- a/examples/example-bayesian-linear-regression.jl
+++ b/examples/example-bayesian-linear-regression.jl
@@ -83,3 +83,7 @@ size(predictor_marginal)
 # Draw a single sample from each of the marginal posterior predictive distributions:
 
 only.(rand.(predictor_marginal))
+
+# Use cross validation to evaluate the model with respect to the L2 loss:
+
+MLJ.evaluate!(mach, resampling=MLJ.CV(; shuffle = true), measure=l2, operation=predict_mean)

--- a/src/model.jl
+++ b/src/model.jl
@@ -44,3 +44,9 @@ function predict_joint(sm::SossMLJModel, fitresult, Xnew)
     args = merge(sm.transform(Xnew), sm.hyperparams)
     return SossMLJPredictor(sm, post, pred, args)
 end
+
+function MMI.predict_mean(sm::SossMLJModel, fitresult, Xnew)
+    # predictor_joint = MMI.predict_joint(sm, fitresult, Xnew)
+    predictor_joint = predict_joint(sm, fitresult, Xnew)
+    return Statistics.mean(predict_particles(predictor_joint, Xnew).yhat)
+end


### PR DESCRIPTION
I'm not sure if this is the correct way to implement this.

@cscherrer 

---

## Motivation

Once we define `MLJModelInterface.predict_mean`, we can easily do cross-validation.

E.g. with the L2 loss function:
```julia
MLJ.evaluate!(mach, resampling=MLJ.CV(; shuffle = true), measure=l2, operation=predict_mean)
```

Example output:
```julia
julia> MLJ.evaluate!(mach, resampling=MLJ.CV(; shuffle = true), measure=l2, operation=predict_mean)
Evaluating over 6 folds: 100%[=========================] Time: 0:00:03
┌───────────┬───────────────┬──────────────────────────────────────────┐
│ _.measure │ _.measurement │ _.per_fold                               │
├───────────┼───────────────┼──────────────────────────────────────────┤
│ l2        │ 1.02          │ [1.33, 0.859, 0.942, 0.917, 0.874, 1.22] │
└───────────┴───────────────┴──────────────────────────────────────────┘
_.per_observation = [[[1.06, 3.75, ..., 0.823], [0.127, 0.0724, ..., 0.755], [0.0724, 3.89, ..., 0.00175], [0.235, 5.17, ..., 0.00808], [1.27, 0.236, ..., 0.468], [1.33, 0.98, ..., 0.0166]]]

```