### PR TITLE
[Docs] Linear regression example: Add a prior (inverse gamma) for the dispersion parameter

### DIFF
--- a/examples/example-bayesian-linear-regression.jl
+++ b/examples/example-bayesian-linear-regression.jl
@@ -13,7 +13,8 @@ using Statistics
 # Use the Soss probabilistic programming language
 # to define a Bayesian linear regression model:
 
-m = @model X,s,σ begin
+m = @model X,s,α,θ begin
+    σ ~ InverseGamma(α,θ)
     k = size(X,2)
     β ~ Normal(0,s) |> iid(k)
     yhat = X * β
@@ -29,7 +30,7 @@ X = (a=randn(num_rows), b=randn(num_rows), c=randn(num_rows))
 
 # Define the hyperparameters of our prior distributions:
 
-hyperparameters = (s=2.0, σ=1.0)
+hyperparameters = (s=2.0, α=1.0, θ=1.0)
 
 # Convert the Soss model into a `SossMLJModel`:
 
@@ -58,6 +59,10 @@ typeof(predictor_joint)
 # Compare the posterior distribution of `β` to the true coefficients `β`:
 
 truth.β - predict_particles(predictor_joint, X).β
+
+# Compare the posterior distribution of `σ` to the true dispersion parameter `σ`:
+
+truth.σ - predict_particles(predictor_joint, X).σ
 
 # Compare the joint posterior predictive distribution to the true labels:
 

--- a/examples/example-bayesian-linear-regression.jl
+++ b/examples/example-bayesian-linear-regression.jl
@@ -13,8 +13,8 @@ using Statistics
 # Use the Soss probabilistic programming language
 # to define a Bayesian linear regression model:
 
-m = @model X,s,a,b begin
-    σ ~ HalfNormal(a,b)
+m = @model X,s,a begin
+    σ ~ HalfNormal(a)
     k = size(X,2)
     β ~ Normal(0,s) |> iid(k)
     yhat = X * β
@@ -30,7 +30,7 @@ X = (x1=randn(num_rows), x2=randn(num_rows), x3=randn(num_rows))
 
 # Define the hyperparameters of our prior distributions:
 
-hyperparameters = (s=2.0, a=0.0, b=1.0)
+hyperparameters = (s=2.0, a=1.0)
 
 # Convert the Soss model into a `SossMLJModel`:
 

--- a/examples/example-bayesian-linear-regression.jl
+++ b/examples/example-bayesian-linear-regression.jl
@@ -13,8 +13,8 @@ using Statistics
 # Use the Soss probabilistic programming language
 # to define a Bayesian linear regression model:
 
-m = @model X,s,α,θ begin
-    σ ~ InverseGamma(α,θ)
+m = @model X,s,a,b begin
+    σ ~ HalfNormal(a,b)
     k = size(X,2)
     β ~ Normal(0,s) |> iid(k)
     yhat = X * β
@@ -26,11 +26,11 @@ end
 # Generate some synthetic features:
 
 num_rows = 100
-X = (a=randn(num_rows), b=randn(num_rows), c=randn(num_rows))
+X = (x1=randn(num_rows), x2=randn(num_rows), x3=randn(num_rows))
 
 # Define the hyperparameters of our prior distributions:
 
-hyperparameters = (s=2.0, α=1.0, θ=1.0)
+hyperparameters = (s=2.0, a=0.0, b=1.0)
 
 # Convert the Soss model into a `SossMLJModel`:
 


### PR DESCRIPTION
Currently, we have the dispersion parameter `σ` as a hyperparameter, which is fixed.

Instead, I thought it might be cool to put a prior on `σ`, and then we can sample from the posterior distribution on `σ`.

This PR puts an inverse gamma prior on `σ`, with shape hyperparameter `α` and scale hyperparameter `θ`.